### PR TITLE
feature to properly close app added (#85)

### DIFF
--- a/main/ui/app_window.py
+++ b/main/ui/app_window.py
@@ -1,5 +1,5 @@
 import os
-
+import signal
 import gi
 import json_config
 
@@ -96,6 +96,7 @@ class SusiAppWindow(Renderer):
         def on_delete(self, *args):
             print('Exiting')
             self.app_window.exit_window()
+            os.kill(os.getppid(), signal.SIGHUP)
 
         def on_mic_button_clicked(self, button):
             Promise(


### PR DESCRIPTION
The main problem was that the after ui is closed, the terminal remains running and only can be closed by ctrl +c.  
This issue is fixed in this commit . When the ui is closed , the terminal window also exits immediately 