### PR TITLE
Passed country_name and country_code to update_location method

### DIFF
--- a/main/states/susi_state_machine.py
+++ b/main/states/susi_state_machine.py
@@ -36,7 +36,7 @@ class Components:
         try:
             res = requests.get('http://ip-api.com/json').json()
             self.susi.update_location(
-                longitude=res['lon'], latitude=res['lat'])
+                longitude=res['lon'], latitude=res['lat'], country_name=res['country'], country_code=res['countryCode'])
 
         except ConnectionError as e:
             logging.error(e)


### PR DESCRIPTION
Fixes 
Send country name and country code in chat.json API #158

Changes
Send country_name and country_code in update_location method.
Refer to the this PR on susi_api_wrapper: https://github.com/fossasia/susi_api_wrapper/pull/45

Screenshots for the changes
NA