### PR TITLE
check if extra wifi parameters gets passed

### DIFF
--- a/access_point/wifi_search.sh
+++ b/access_point/wifi_search.sh
@@ -22,6 +22,13 @@ if [[ $# -lt 2 ]];
 	exit
 fi
 
+if [[ $# -gt 2 ]]; 
+	then echo "You supplied an extra third command. Only two parameters needed!"
+	echo "Usage:"
+	echo "sudo $0 SSID PASSWORD"
+	exit
+fi
+
 cat >> /etc/wpa_supplicant/wpa_supplicant.conf <<EOF
 network={
     ssid="$SSID"


### PR DESCRIPTION
Fixes #187 

Changes
<!-- Add description -->
Will now throw a proper `USAGE message` if user supplies more than 2 parameters for connecting to wifi

Screenshots for the changes
NA