### PR TITLE
Removed Hardcoded paths

### DIFF
--- a/access_point/server/config.sh
+++ b/access_point/server/config.sh
@@ -1,8 +1,12 @@
 #! /bin/bash
+
+SCRIPT_PATH=$(realpath $0)
+DIR_PATH=$(dirname $SCRIPT_PATH)
+
 STT="$1"
 TTS="$2"
 HOTWORD="$3"
 WAKE="$4"
 
-cd /home/pi/SUSI.AI/susi_linux
+cd $DIR_PATH/../../
 sudo python3 config_generator.py $STT $TTS $HOTWORD $WAKE

--- a/access_point/server/login.sh
+++ b/access_point/server/login.sh
@@ -1,7 +1,11 @@
 #! /bin/bash
+
+SCRIPT_PATH=$(realpath $0)
+DIR_PATH=$(dirname $SCRIPT_PATH)
+
 AUTH="$1"
 EMAIL="$2"
 PASSWORD="$3"
 
-cd /home/pi/SUSI.AI/susi_linux/
+cd $DIR_PATH/../../
 sudo python3 authentication.py $AUTH $EMAIL $PASSWORD

--- a/access_point/server/server.py
+++ b/access_point/server/server.py
@@ -1,5 +1,9 @@
 from flask import Flask , render_template
 import subprocess   # nosec #pylint-disable type: ignore
+import os
+
+access_point_folder = os.path.dirname(os.path.abspath(__file__))
+server_folder = os.path.join(access_point_folder, 'server')
 
 app = Flask(__name__)
 
@@ -13,19 +17,19 @@ def install():
 
 @app.route('/config/<stt>/<tts>/<hotword>/<wake>')
 def config(stt, tts, hotword, wake):
-    subprocess.call(['sudo', 'bash' , 'server/config.sh', stt, tts, hotword, wake])  #nosec #pylint-disable type: ignore
+    subprocess.call(['sudo', 'bash' , server_folder + '/config.sh', stt, tts, hotword, wake])  #nosec #pylint-disable type: ignore
     return 'Done' # pylint-enable
 
 @app.route('/auth/<auth>/<email>/<passwd>')
 def login(auth, email, passwd):
-    subprocess.call(['sudo', 'bash', '/home/pi/SUSI.AI/susi_linux/access_point/server/login.sh', auth, email, passwd]) #nosec #pylint-disable type: ignore
+    subprocess.call(['sudo', 'bash', server_folder + '/login.sh', auth, email, passwd]) #nosec #pylint-disable type: ignore
     return 'Authenticated' # pylint-enable
 
 @app.route('/wifi_credentials/<wifissid>/<wifipassd>')
 def wifi_config(wifissid,wifipassd):
     wifi_ssid = wifissid
     wifi_password = wifipassd
-    subprocess.call(['sudo', 'bash', '/home/pi/SUSI.AI/susi_linux/access_point/wifi_search.sh', wifi_ssid, wifi_password])  #nosec #pylint-disable type: ignore
+    subprocess.call(['sudo', 'bash', access_point_folder + '/wifi_search.sh', wifi_ssid, wifi_password])  #nosec #pylint-disable type: ignore
     return 'Wifi Configured' # pylint-enable
 
 if __name__ == '__main__':

--- a/factory_reset/factory_reset.sh
+++ b/factory_reset/factory_reset.sh
@@ -1,7 +1,10 @@
 #! /bin/bash
 # To be executed using a physical button
 
-cd $HOME/SUSI.AI/susi_linux
+SCRIPT_PATH=$(realpath $0)
+DIR_PATH=$(dirname $SCRIPT_PATH)
+
+cd $DIR_PATH/../..
 pwd
 mv susi_linux/ susi_temp
 git clone https://github.com/fossasia/susi_linux #while testing change to personal repo

--- a/media_daemon/auto_skills.py
+++ b/media_daemon/auto_skills.py
@@ -3,6 +3,12 @@ from glob import glob
 import shutil
 from subprocess import check_output #nosec #pylint-disable type: ignore
 
+# To get media_daemon folder
+media_daemon_folder = os.path.dirname(os.path.abspath(__file__))
+base_folder = os.path.dirname(media_daemon_folder)
+server_skill_folder = os.path.join(base_folder, 'susi_server/susi_server/data/generic_skills/media_discovery')
+server_settings_folder = os.path.join(base_folder, 'susi_server/susi_server/data/settings')
+
 def make_skill(): # pylint-enable
     name_of_usb = get_mount_points()
     print(type(name_of_usb))
@@ -11,23 +17,20 @@ def make_skill(): # pylint-enable
     os.chdir('{}'.format(x[1]))
     USB = name_of_usb[0]
     mp3 = [file for file in glob("*.mp3")]
-    os.chdir(os.path.expanduser('~/SUSI.AI/susi_linux/media_daemon'))
-    f = open('custom_skill.txt','w')
+    f = open( media_daemon_folder +'/custom_skill.txt','w')
     music_path = list()
     for mp in mp3:
         music_path.append("{}".format(USB[1]) + "/{}".format(mp))
 
     song_list = " ".join(music_path)
-    skills = ['play audio','!console:Playing audio from your usb device','{"actions":[','{"type":"audio_play", "identifier_type":"url", "identifier":"file://"'+str(song_list) +'}',']}','eol']
+    skills = ['play audio','!console:Playing audio from your usb device','{"actions":[','{"type":"audio_play", "identifier_type":"url", "identifier":"file://'+str(song_list) +'"}',']}','eol']
     for skill in skills:
         f.write(skill + '\n')
     f.close()
-    shutil.move('/home/pi/SUSI.AI/susi_linux/media_daemon/custom_skill.txt','/home/pi/SUSI.AI/susi_linux/susi_server/susi_server/data/generic_skills/media_discovery')
-    os.chdir(os.path.expanduser('~/SUSI.AI/susi_linux/susi_server/susi_server/data/settings/'))
-    f2 = open('customized_config.properties','a')
+    shutil.move( media_daemon_folder + 'custom_skill.txt', server_skill_folder)
+    f2 = open(server_settings_folder + 'customized_config.properties','a')
     f2.write('local.mode = true')
     f2.close()
-    os.chdir(os.path.expanduser('~/SUSI.AI/susi_linux/'))
 
 def get_usb_devices():
     sdb_devices = map(os.path.realpath, glob('/sys/block/sd*'))

--- a/media_daemon/autostart.sh
+++ b/media_daemon/autostart.sh
@@ -2,10 +2,13 @@
 
 clear
 
-cd $HOME/SUSI.AI/susi_linux/
+SCRIPT_PATH=$(realpath $0)
+DIR_PATH=$(dirname $SCRIPT_PATH)
+
+cd $DIR_PATH/../susi_server/
 if [ -d "susi_server" ]
 then
-    cd $HOME/SUSI.AI/susi_linux/media_daemon/
+    cd $DIR_PATH
     python3 auto_skills.py
 else
     echo "Please download Skill Data"

--- a/media_daemon/autostop.sh
+++ b/media_daemon/autostop.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
-cd $HOME/SUSI.AI/susi_linux/media_daemon
+SCRIPT_PATH=$(realpath $0)
+DIR_PATH=$(dirname $SCRIPT_PATH)
+
+cd $DIR_PATH/../susi_server/susi_server/data/generic_skills/media_discovery/
  
 sudo rm custom_skill.txt 


### PR DESCRIPTION
#237 

Removed hardcoded paths from the repo

A definitive path is difficult to remove from `99-susi-usb-drive.rules` file as it will not be executed as a script. But what can be done is instead of using `/home/pi/SUSI.AI` , `~/SUSI.AI` can be used which will eliminate the factor of having a user named `pi` but will still restrict the user to make a `SUSI.AI` folder in the home directory