### PR TITLE
Fix seeed drivers not found

### DIFF
--- a/main/states/led.py
+++ b/main/states/led.py
@@ -14,10 +14,9 @@ class LED_COLOR:
 
     def __init__(self, num_led, global_brightness=MAX_BRIGHTNESS,
                  order='rgb', bus=0, device=1, max_speed_hz=8000000):
-        output = subprocess.check_output(["aplay", "-l"])
-        output = output.decode(sys.stdout.encoding)
-        self.driverInstalled = output.find("seeed") != -1
-        if (not self.driverInstalled):
+        output = subprocess.check_output(["aplay", "-l"]).decode(sys.stdout.encoding)
+        self.driver_installed  = output.find("seeed") != -1
+        if (not self.driver_installed ):
             return
         self.num_led = num_led  # The number of LEDs in the Strip
         order = order.lower()
@@ -36,14 +35,14 @@ class LED_COLOR:
             self.spi.max_speed_hz = max_speed_hz
 
     def clock_start_frame(self):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """Sends a start frame to the LED strip.
         """
         self.spi.xfer2([0] * 4)  # Start frame, 32 zero bits
 
     def clock_end_frame(self):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         self.spi.xfer2([0xFF] * 4)
 
@@ -52,7 +51,7 @@ class LED_COLOR:
         #    self.spi.xfer2([0x00])
 
     def clear_strip(self):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """ Turns off the strip and shows the result right away."""
 
@@ -61,7 +60,7 @@ class LED_COLOR:
         self.show()
 
     def set_pixel(self, led_num, red, green, blue, bright_percent=100):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """Sets the color of one pixel in the LED stripe.
 
@@ -89,7 +88,7 @@ class LED_COLOR:
         self.leds[start_index + self.rgb[2]] = blue
 
     def set_pixel_rgb(self, led_num, rgb_color, bright_percent=100):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """Sets the color of one pixel in the LED stripe.
 
@@ -102,7 +101,7 @@ class LED_COLOR:
                        (rgb_color & 0x00FF00) >> 8, rgb_color & 0x0000FF, bright_percent)
 
     def rotate(self, positions=1):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """ Rotate the LEDs by the specified number of positions.
 
@@ -114,7 +113,7 @@ class LED_COLOR:
         self.leds = self.leds[cutoff:] + self.leds[:cutoff]
 
     def show(self):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """Sends the content of the pixel buffer to the strip.
 
@@ -130,7 +129,7 @@ class LED_COLOR:
         self.clock_end_frame()
 
     def cleanup(self):
-        if (not self.driverInstalled):
+        if (not self.driver_installed ):
             return
         """Release the SPI device; Call this method at the end"""
         self.spi.close()  # Close SPI port

--- a/main/states/led.py
+++ b/main/states/led.py
@@ -14,7 +14,9 @@ class LED_COLOR:
 
     def __init__(self, num_led, global_brightness=MAX_BRIGHTNESS,
                  order='rgb', bus=0, device=1, max_speed_hz=8000000):
-        self.driverInstalled = subprocess.check_output(["aplay", "-l"]).decode(sys.stdout.encoding).find("seeed") != -1
+        output = subprocess.check_output(["aplay", "-l"])
+        output = output.decode(sys.stdout.encoding)
+        self.driverInstalled = output.find("seeed") != -1
         if (not self.driverInstalled):
             return
         self.num_led = num_led  # The number of LEDs in the Strip

--- a/main/states/led.py
+++ b/main/states/led.py
@@ -1,4 +1,6 @@
 import spidev
+import subprocess
+import sys
 from math import ceil
 
 RGB_MAP = {'rgb': [3, 2, 1], 'rbg': [3, 1, 2], 'grb': [2, 3, 1], 'gbr': [2, 1, 3], 'brg': [1, 3, 2], 'bgr': [1, 2, 3]}
@@ -12,6 +14,9 @@ class LED_COLOR:
 
     def __init__(self, num_led, global_brightness=MAX_BRIGHTNESS,
                  order='rgb', bus=0, device=1, max_speed_hz=8000000):
+        self.driverInstalled = subprocess.check_output(["aplay", "-l"]).decode(sys.stdout.encoding).find("seeed") != -1
+        if (not self.driverInstalled):
+            return
         self.num_led = num_led  # The number of LEDs in the Strip
         order = order.lower()
         self.rgb = RGB_MAP.get(order, RGB_MAP['rgb'])
@@ -29,11 +34,15 @@ class LED_COLOR:
             self.spi.max_speed_hz = max_speed_hz
 
     def clock_start_frame(self):
+        if (not self.driverInstalled):
+            return
         """Sends a start frame to the LED strip.
         """
         self.spi.xfer2([0] * 4)  # Start frame, 32 zero bits
 
     def clock_end_frame(self):
+        if (not self.driverInstalled):
+            return
         self.spi.xfer2([0xFF] * 4)
 
         # Round up num_led/2 bits (or num_led/16 bytes)
@@ -41,6 +50,8 @@ class LED_COLOR:
         #    self.spi.xfer2([0x00])
 
     def clear_strip(self):
+        if (not self.driverInstalled):
+            return
         """ Turns off the strip and shows the result right away."""
 
         for led in range(self.num_led):
@@ -48,6 +59,8 @@ class LED_COLOR:
         self.show()
 
     def set_pixel(self, led_num, red, green, blue, bright_percent=100):
+        if (not self.driverInstalled):
+            return
         """Sets the color of one pixel in the LED stripe.
 
         The changed pixel is not shown yet on the Stripe, it is only
@@ -74,6 +87,8 @@ class LED_COLOR:
         self.leds[start_index + self.rgb[2]] = blue
 
     def set_pixel_rgb(self, led_num, rgb_color, bright_percent=100):
+        if (not self.driverInstalled):
+            return
         """Sets the color of one pixel in the LED stripe.
 
         The changed pixel is not shown yet on the Stripe, it is only
@@ -85,6 +100,8 @@ class LED_COLOR:
                        (rgb_color & 0x00FF00) >> 8, rgb_color & 0x0000FF, bright_percent)
 
     def rotate(self, positions=1):
+        if (not self.driverInstalled):
+            return
         """ Rotate the LEDs by the specified number of positions.
 
         Treating the internal LED array as a circular buffer, rotate it by
@@ -95,6 +112,8 @@ class LED_COLOR:
         self.leds = self.leds[cutoff:] + self.leds[:cutoff]
 
     def show(self):
+        if (not self.driverInstalled):
+            return
         """Sends the content of the pixel buffer to the strip.
 
         Todo: More than 1024 LEDs requires more than one xfer operation.
@@ -109,6 +128,8 @@ class LED_COLOR:
         self.clock_end_frame()
 
     def cleanup(self):
+        if (not self.driverInstalled):
+            return
         """Release the SPI device; Call this method at the end"""
         self.spi.close()  # Close SPI port
 

--- a/main/states/led.py
+++ b/main/states/led.py
@@ -3,7 +3,8 @@ import subprocess
 import sys
 from math import ceil
 
-RGB_MAP = {'rgb': [3, 2, 1], 'rbg': [3, 1, 2], 'grb': [2, 3, 1], 'gbr': [2, 1, 3], 'brg': [1, 3, 2], 'bgr': [1, 2, 3]}
+RGB_MAP = {'rgb': [3, 2, 1], 'rbg': [3, 1, 2], 'grb': [
+    2, 3, 1], 'gbr': [2, 1, 3], 'brg': [1, 3, 2], 'bgr': [1, 2, 3]}
 
 
 class LED_COLOR:
@@ -14,9 +15,10 @@ class LED_COLOR:
 
     def __init__(self, num_led, global_brightness=MAX_BRIGHTNESS,
                  order='rgb', bus=0, device=1, max_speed_hz=8000000):
-        output = subprocess.check_output(["aplay", "-l"]).decode(sys.stdout.encoding)
-        self.driver_installed  = output.find("seeed") != -1
-        if (not self.driver_installed ):
+        output = subprocess.check_output(
+            ["aplay", "-l"]).decode(sys.stdout.encoding)
+        self.driver_installed = output.find("seeed") != -1
+        if (not self.driver_installed):
             return
         self.num_led = num_led  # The number of LEDs in the Strip
         order = order.lower()
@@ -35,14 +37,14 @@ class LED_COLOR:
             self.spi.max_speed_hz = max_speed_hz
 
     def clock_start_frame(self):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """Sends a start frame to the LED strip.
         """
         self.spi.xfer2([0] * 4)  # Start frame, 32 zero bits
 
     def clock_end_frame(self):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         self.spi.xfer2([0xFF] * 4)
 
@@ -51,7 +53,7 @@ class LED_COLOR:
         #    self.spi.xfer2([0x00])
 
     def clear_strip(self):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """ Turns off the strip and shows the result right away."""
 
@@ -60,7 +62,7 @@ class LED_COLOR:
         self.show()
 
     def set_pixel(self, led_num, red, green, blue, bright_percent=100):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """Sets the color of one pixel in the LED stripe.
 
@@ -88,7 +90,7 @@ class LED_COLOR:
         self.leds[start_index + self.rgb[2]] = blue
 
     def set_pixel_rgb(self, led_num, rgb_color, bright_percent=100):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """Sets the color of one pixel in the LED stripe.
 
@@ -101,7 +103,7 @@ class LED_COLOR:
                        (rgb_color & 0x00FF00) >> 8, rgb_color & 0x0000FF, bright_percent)
 
     def rotate(self, positions=1):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """ Rotate the LEDs by the specified number of positions.
 
@@ -113,7 +115,7 @@ class LED_COLOR:
         self.leds = self.leds[cutoff:] + self.leds[:cutoff]
 
     def show(self):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """Sends the content of the pixel buffer to the strip.
 
@@ -129,7 +131,7 @@ class LED_COLOR:
         self.clock_end_frame()
 
     def cleanup(self):
-        if (not self.driver_installed ):
+        if (not self.driver_installed):
             return
         """Release the SPI device; Call this method at the end"""
         self.spi.close()  # Close SPI port


### PR DESCRIPTION
Another approach of #264
This approach will check if seeed is installed by running `aplay -l` and check if string `"seeed"` exists in its output. 
This way, codes can still run even without the driver should we not use seeed's respeaker in the future.