### PR TITLE
Added pulseAudio installation to the repo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ install_debian_dependencies()
 {
     sudo -E apt install -y python3-pip sox libsox-fmt-all flac \
     libportaudio2 libatlas3-base libpulse0 libasound2 \
-    python3-cairo python3-flask mpv flite ca-certificates-java pixz udisks2
+    python3-cairo python3-flask mpv flite ca-certificates-java pixz udisks2 \
+    pulseaudio pavucontrol
     # We specify ca-certificates-java instead of openjdk-(8/9)-jre-headless, so that it will pull the
     # appropriate version of JRE-headless, which can be 8 or 9, depending on ARM6 or ARM7 platform.
     # libatlas3-base is to provide libf77blas.so, liblapack_atlas.so for snowboy.


### PR DESCRIPTION
Fixes #367 

Adds pulseAudio and pavucontrol which are essential libraries to choose the default sound I/O driver