### PR TITLE
Use sox to play startup audio

### DIFF
--- a/Deploy/Systemd/ss-startup-audio.service
+++ b/Deploy/Systemd/ss-startup-audio.service
@@ -4,7 +4,8 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/mpg123 /home/pi/SUSI.AI/susi_linux/wav/ting-ting_susi_is_alive_and_listening.wav
+User=pi
+ExecStart=/usr/bin/play -q /home/pi/SUSI.AI/susi_linux/main/wav/ting-ting_susi_is_alive_and_listening.wav
 
 [Install]
 WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,7 @@ install_debian_dependencies()
 {
     sudo -E apt install -y python3-pip sox libsox-fmt-all flac \
     libportaudio2 libatlas3-base libpulse0 libasound2 \
-    python3-cairo python3-flask mpv flite ca-certificates-java pixz udisks2 \
-    pulseaudio pavucontrol
+    python3-cairo python3-flask mpv flite ca-certificates-java pixz udisks2
     # We specify ca-certificates-java instead of openjdk-(8/9)-jre-headless, so that it will pull the
     # appropriate version of JRE-headless, which can be 8 or 9, depending on ARM6 or ARM7 platform.
     # libatlas3-base is to provide libf77blas.so, liblapack_atlas.so for snowboy.


### PR DESCRIPTION
Previously, we use `mpg123`, but it is not necessary to do so (have to install more software).