### PR TITLE
Add missing RPi.GPIO

### DIFF
--- a/requirements-hw.txt
+++ b/requirements-hw.txt
@@ -10,6 +10,7 @@ rx
 python-Levenshtein
 pyalsaaudio
 spidev
+RPi.GPIO
 
 # Repo for wheel packages, pre-compiled for ARM
 --extra-index-url https://repo.fury.io/fossasia/


### PR DESCRIPTION
This is to fix the problem that SUSI Linux only work once with hotword then stop.