### PR TITLE
Don't start services before rebooting

### DIFF
--- a/access_point/wap.sh
+++ b/access_point/wap.sh
@@ -56,10 +56,7 @@ echo "denyinterfaces wlan0" >> /etc/dhcpcd.conf
 systemctl enable hostapd
 systemctl enable dnsmasq
 
-sudo service hostapd start
-sudo service dnsmasq start
-
-# add server in the auto-boot up list 
+# add server in the auto-boot up list
 echo "All done! Rebooting"
 
 sudo reboot

--- a/install.sh
+++ b/install.sh
@@ -64,15 +64,13 @@ function install_susi_server() {
 
     if [ -d $SUSI_SERVER_PATH ]
     then
-        echo "Deploying local server"
+        echo "Deploying local SUSI server"
         cd $SUSI_SERVER_PATH
         {
             ./gradlew build
         } || {
             echo PASS
         }
-
-        bin/start.sh
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,8 @@ function install_susi_server() {
         cd $SUSI_SERVER_PATH
         {
             ./gradlew build
+            # Stop Gradle daemons after building
+            ./gradlew --stop
         } || {
             echo PASS
         }


### PR DESCRIPTION
At the end of install.sh script, we will reboot RPi, so no need to start some systemd services.

Those services cause issue when the install script is run in OS image build environment.