### PR TITLE
Avoid triggerring systemd daemon in install script

### DIFF
--- a/Deploy/auto_boot.sh
+++ b/Deploy/auto_boot.sh
@@ -7,7 +7,6 @@ DIR_PATH=$(dirname $SCRIPT_PATH)
 
 cp $DIR_PATH/Systemd/ss-*.service /lib/systemd/system/
 
-systemctl daemon-reload
 systemctl enable ss-update-daemon.service
 systemctl enable ss-susi-server.service
 systemctl enable ss-python-flask.service

--- a/access_point/rwap.sh
+++ b/access_point/rwap.sh
@@ -16,7 +16,6 @@ sed -i '9,17d' interfaces
 
 #Empty port 5000
 #Remove the server file from auto-boot
-sudo systemctl daemon-reload
 sudo systemctl enable ss-startup-audio.service
 sudo systemctl enable ss-susi-linux.service
 sudo systemctl disable ss-python-flask.service

--- a/media_daemon/media_udev_rule.sh
+++ b/media_daemon/media_udev_rule.sh
@@ -13,5 +13,3 @@ ACTION==\"remove\", KERNEL==\"sd?\", SUBSYSTEM==\"block\", ENV{ID_BUS}==\"usb\",
 
 echo "Copy udev rules to trigger Media Discovery"
 sudo cp $DIR_PATH/$RULE_NAME /etc/udev/rules.d/
-
-sudo service udev restart


### PR DESCRIPTION
The install script has some actions which invoke systemd daemons (like `systemd-udevd`). This daemon then make custom Raspbian build script [fail](https://github.com/fossasia/susi_linux/issues/382#issuecomment-427439935).

In this PR, we delete those actions. Those actions are also unnecessary outside the image build script, because after installation, RPi is rebooted anyway.