### PR TITLE
Buildkite Pipeline to trigger image build.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,6 @@
+# This pipeline will trigger another pipeline on pi-gen repo
+- trigger: "build-susibian"
+  label: ":cherries: Build SUSIbian"
+  build:
+    branch: "susi"
+    message: Continue from "${BUILDKITE_MESSAGE}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,6 @@
-# This pipeline will trigger another pipeline on pi-gen repo
+# This pipeline will trigger another pipeline on pi-gen repo.
+# To trigger this pipeline, merge the code to "build-image" branch and push.
+
 - trigger: "build-susibian"
   label: ":cherries: Build SUSIbian"
   build:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,4 +5,4 @@
   label: ":cherries: Build SUSIbian"
   build:
     branch: "susi"
-    message: Continue from "${BUILDKITE_MESSAGE}"
+    message: Continue from "${BUILDKITE_MESSAGE:0:40}"


### PR DESCRIPTION
This is to solve #406.

As explained in #406, this PR choose approach of building on real Raspberry Pi 3 hardware (not QEMU/ virtual machine). Because Travis doesn't support running the job on our machine, I use [Buildkite service](https://buildkite.com/fossasia/) instead.

Buildkite has "agent" part, which is installed and run on our machine. Because the repo to trigger the event and the repo containing the script to do actual build are different, we have to setup 2 Buildkite Pipelines for our 2 repos: One on `susi_linux` repo and one on `pi-gen` repo. The 1st one is to trigger the 2nd, which executes the script there to build image.

Because the build process takes long time, we won't let it run often. I plan to let it run only when the `build-image` branch (of `susi_linux` repo) is pushed.

The Pipeline on `pi-gen` repo is split to 2 steps: Generate image and upload image. The 1st step should be runnable on any Raspberry Pi (with `buildkite-agent` installed). The 2nd is dependent. Currently, I am making it upload to my company server (agriconnect.vn), so it can only run on my RPi, which can establish SSH connection to my company server.

After uploading successfully, the image file will appear at ftp://agriconnect.vn:2121

Before making this PR, I already test the pipelines with my private account on Buildkite. The build logs were attached in #406 for you to check.

### Limitation and further improvement:

- Build time is still long (1 - 2h). It can be reduced by:
    + Download _susi_server_ tarball instead of "git clone" it.
    + Cache Python packages and Gradle. Reuse that cache to save download time.
    + Place the RPi somewhere with better Internet connection.
- Need to have some host to upload the image. If it is still uploaded to my company server, I cannot share the upload right to other developers.