### PR TITLE
Fix: Failed to import URLError

### DIFF
--- a/main/states/internet_test.py
+++ b/main/states/internet_test.py
@@ -1,7 +1,7 @@
 """ Function to test the internet connection
 """
 import urllib.request
-from urllib import URLError
+from urllib.error import URLError
 
 
 def internet_on():


### PR DESCRIPTION
This error cause susi_linux crashing at start-up.