### PR TITLE
Remove ReSpeaker repo from travis script.

### DIFF
--- a/.travis_scripts/install.sh
+++ b/.travis_scripts/install.sh
@@ -12,10 +12,7 @@ add_fossasia_repo() {
 }
 
 add_debian_repo() {
-    echo "Add ReSpeaker Debian repo"
-    # Respeaker driver https://github.com/respeaker/deb
-    wget -qO- http://respeaker.io/deb/public.key | sudo apt-key add -
-    echo "deb http://respeaker.io/deb/ stretch main" | sudo tee /etc/apt/sources.list.d/respeaker.list
+	# Add extra debian repo here, if needed
     sudo apt update
 }
 


### PR DESCRIPTION
This repo doesn't have pre-packaged voice card driver.

This PR is minor, main objective is to test Image Build with Buildkite Pipeline.