### PR TITLE
Fixes: ReSpeaker Volume Error

### DIFF
--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -72,9 +72,8 @@ class BusyState(State):
                     stopAction.detector.terminate()
 
             if 'volume' in reply.keys():
-                subprocess.call(['amixer','-c','1','sset',"'Headphone'",',','0',str(reply['volume']])
-                subprocess.call(['amixer','-c','1','sset',"'Speaker'",',','0',str(reply['volume']])
-                # # amixer -c 1 sset 'Headphone',0 60%
+                subprocess.call(['amixer', '-c', '1', 'sset', "'Headphone'", ',', '0', str(reply['volume']])
+                subprocess.call(['amixer', '-c', '1', 'sset', "'Speaker'", ',', '0', str(reply['volume']])
                 subprocess.call(['play', str(self.components.config['detection_bell_sound'])])  # nosec #pylint-disable type: ignore
 
             if 'table' in reply.keys():

--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -72,8 +72,9 @@ class BusyState(State):
                     stopAction.detector.terminate()
 
             if 'volume' in reply.keys():
-                m = alsaaudio.Mixer()
-                m.setvolume(int(reply['volume']))
+                subprocess.call(['amixer','-c','1','sset',"'Headphone'",',','0',str(reply['volume']])
+                subprocess.call(['amixer','-c','1','sset',"'Speaker'",',','0',str(reply['volume']])
+                # # amixer -c 1 sset 'Headphone',0 60%
                 subprocess.call(['play', str(self.components.config['detection_bell_sound'])])  # nosec #pylint-disable type: ignore
 
             if 'table' in reply.keys():


### PR DESCRIPTION
Fixes #431 

Checklist
 [x]-I have read the Contribution & Best practices Guide and my PR follows them.
 [x]-My branch is up-to-date with the Upstream master branch.
 [x]-The unit tests pass locally with my changes
 [x]-I have added tests that prove my fix is effective or that my feature works
 [x]-I have added necessary documentation (if appropriate)
 [x]-All the functions created/modified in this PR contain relevant docstrings.

Test Passing
[x]- The SUSI Server must be building on the pi on bootup
[x]- The hotword detection should have a decent accuracy
[]- SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
[]- SUSI Linux should be able to boot offline when no internet connection available (failing)

Short description of what this resolves:
This PR fixes the issues with Volume modulation on ReSpeaker. As I do not have the speakers that connect to the PiHat port, I was able to test only the 3.5mm Jack's volume modulation on the PiHat.

