### PR TITLE
enabling SSH by default in the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,10 @@ install_susi_server
 echo "Updating Systemd Rules"
 sudo bash $DIR_PATH/Deploy/auto_boot.sh
 
+echo "Enabling the SSH access"
+sudo systemctl enable ssh
+sudo systemctl start ssh
+
 cd $DIR_PATH
 echo "Creating a backup folder for future factory_reset"
 tar -I 'pixz -p 2' -cf ../reset_folder.tar.xz --checkpoint=.1000 -C .. susi_linux


### PR DESCRIPTION
Fixes#

Checklist
 [x]-I have read the Contribution & Best practices Guide and my PR follows them.
 [x]-My branch is up-to-date with the Upstream master branch.
 [x]-The unit tests pass locally with my changes
 [x]-I have added tests that prove my fix is effective or that my feature works
 [x]-I have added necessary documentation (if appropriate)
 [x]-All the functions created/modified in this PR contain relevant docstrings.

Test Passing
[x]- The SUSI Server must be building on the pi on bootup
[x]- The hotword detection should have a decent accuracy
[]- SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
[]- SUSI Linux should be able to boot offline when no internet connection available (failing)

Short description of what this resolves:
Altered the install script to allow SSH connections by default in the program
