### PR TITLE
Fix syntax in GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,32 +4,32 @@ about: Create a report to help us improve
 
 ---
 
-**Describe the bug**
+#### Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+#### To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+#### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+#### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
+#### Desktop (please complete the following information):
+ - OS: [e.g. Windows 10, Ubuntu 18.10]
+ - Browser [e.g. Chrome, Safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+#### Smartphone (please complete the following information):
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
+ - Browser [e.g. stock browser, Safari]
  - Version [e.g. 22]
 
-**Additional context**
+#### Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,14 +4,14 @@ about: Suggest an idea for this project
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+#### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+#### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,21 @@
-Fixes#
+Fixes #
 
-Checklist
- []-I have read the Contribution & Best practices Guide and my PR follows them.
- []-My branch is up-to-date with the Upstream master branch.
- []-The unit tests pass locally with my changes
- []-I have added tests that prove my fix is effective or that my feature works
- []-I have added necessary documentation (if appropriate)
- []-All the functions created/modified in this PR contain relevant docstrings.
+#### Checklist
 
-Test Passing
-[]- The SUSI Server must be building on the pi on bootup
-[]- The hotword detection should have a decent accuracy
-[]- SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
-[]- SUSI Linux should be able to boot offline when no internet connection available (failing)
+- [ ] I have read the Contribution & Best practices Guide and my PR follows them.
+- [ ] My branch is up-to-date with the Upstream master branch.
+- [ ] The unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] All the functions created/modified in this PR contain relevant docstrings.
 
-Short description of what this resolves:
+#### Test Passing
 
-Changes proposed in this pull request:
+- [ ] The SUSI Server must be building on the pi on bootup
+- [ ] The hotword detection should have a decent accuracy
+- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
+- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)
+
+#### Short description of what this resolves:
+
+#### Changes proposed in this pull request:


### PR DESCRIPTION
- Fix checklist.
- Use heading instead of bold text.