### PR TITLE
Install just enough VLC components for non-GUI environment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ add_latest_drivers_vlc() {
 install_debian_dependencies()
 {
     sudo -E apt-get install -y python3-pip sox libsox-fmt-all flac \
-    libportaudio2 libatlas3-base libpulse0 libasound2 vlc\
+    libportaudio2 libatlas3-base libpulse0 libasound2 vlc-bin vlc-plugin-base vlc-plugin-video-splitter \
     python3-cairo python3-flask flite ca-certificates-java pixz udisks2 \
     # We specify ca-certificates-java instead of openjdk-(8/9)-jre-headless, so that it will pull the
     # appropriate version of JRE-headless, which can be 8 or 9, depending on ARM6 or ARM7 platform.


### PR DESCRIPTION
Fixes #

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
Installing full `vlc` will pull a lot of packages for showing VLC in window. This is redundant because our RPi is not meant to run with any GUI, and it make the OS image big. This PR is to install just-enough VLC.
