### PR TITLE
Fix: Fail to catch exception when there is no Internet

### DIFF
--- a/main/states/susi_state_machine.py
+++ b/main/states/susi_state_machine.py
@@ -8,6 +8,7 @@ import requests
 import json_config
 import susi_python as susi
 from speech_recognition import Recognizer, Microphone
+from requests.exceptions import ConnectionError
 
 from .busy_state import BusyState
 from .error_state import ErrorState
@@ -46,7 +47,8 @@ class Components:
         try:
             res = requests.get('http://ip-api.com/json').json()
             self.susi.update_location(
-                longitude=res['lon'], latitude=res['lat'], country_name=res['country'], country_code=res['countryCode'])
+                longitude=res['lon'], latitude=res['lat'],
+                country_name=res['country'], country_code=res['countryCode'])
 
         except ConnectionError as e:
             logger.error(e)


### PR DESCRIPTION
Attempt to fix #459

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:

Please read my analysis in https://github.com/fossasia/susi_linux/issues/459#issuecomment-466738776

#### Changes proposed in this pull request:
