### PR TITLE
update github download url for VLC youtube.lua

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ add_debian_repo() {
 
 add_latest_drivers_vlc() {
     # function to update the latest vlc drivers which will allow it to play MRL of latest videos
-    wget -P /home/pi  https://github.com/videolan/vlc/blob/master/share/lua/playlist/youtube.lua
+    wget -P /home/pi  https://raw.githubusercontent.com/videolan/vlc/master/share/lua/playlist/youtube.lua
     sudo mv /home/pi/youtube.lua /usr/lib/arm-linux-gnueabihf/vlc/lua/playlist/youtube.luac
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:

github doesn't allow downloading of files via github.com/, we need to use a new URL for updating the youtube.lua file from VLC

#### Changes proposed in this pull request:

update the URL