### PR TITLE
stop and disable hostapd when wap setup was done

### DIFF
--- a/access_point/rwap.sh
+++ b/access_point/rwap.sh
@@ -5,6 +5,11 @@ if [ "$EUID" -ne 0 ]
 	exit
 fi
 
+# stop and disable hostapd, it cannot run once we have set up wifi
+# and would be re-enabled in wap.sh if necessary
+systemctl stop hostapd
+systemctl disable hostapd
+
 cd /etc/hostapd/
 cp hostapd.conf hostapd.conf.bak
 sed -i '1,14d' hostapd.conf


### PR DESCRIPTION
#### Short description of what this resolves:

After setting up wifi on the susi.ai speaker, hostapd service is still running, and leaves permanent logging like:
```
Mar 25 15:41:37 raspberrypi systemd[1]: hostapd.service: Service hold-off time over, scheduling restart.
Mar 25 15:41:37 raspberrypi systemd[1]: Stopped Advanced IEEE 802.11 AP and IEEE 802.1X/WPA/WPA2/EAP Authenticator.
Mar 25 15:41:37 raspberrypi systemd[1]: Starting Advanced IEEE 802.11 AP and IEEE 802.1X/WPA/WPA2/EAP Authenticator...
Mar 25 15:41:37 raspberrypi hostapd[3698]: Configuration file: /etc/hostapd/hostapd.conf
Mar 25 15:41:37 raspberrypi hostapd[3698]: Interface name not specified in /etc/hostapd/hostapd.conf, nor by '-i' parameter
Mar 25 15:41:37 raspberrypi hostapd[3698]: : interface state UNINITIALIZED->DISABLED
Mar 25 15:41:37 raspberrypi hostapd[3698]: : AP-DISABLED
Mar 25 15:41:37 raspberrypi hostapd[3698]: hostapd_free_hapd_data: Interface  wasn't started
Mar 25 15:41:37 raspberrypi hostapd[3698]: Failed to initialize interface
Mar 25 15:41:37 raspberrypi systemd[1]: hostapd.service: Control process exited, code=exited status=1
Mar 25 15:41:37 raspberrypi systemd[1]: Failed to start Advanced IEEE 802.11 AP and IEEE 802.1X/WPA/WPA2/EAP Authenticator.
Mar 25 15:41:37 raspberrypi systemd[1]: hostapd.service: Unit entered failed state.
Mar 25 15:41:37 raspberrypi systemd[1]: hostapd.service: Failed with result 'exit-code'.
```

#### Changes proposed in this pull request:

The script `wap.sh` enables hostapd service, but the reverse script `rwap.sh` does not sop/disable it. Add the necessary stop/disable systemctl calls.

Comment: the wap.sh also enables the dnsmasq service. I am not sure if this is a problem when running after setup (I don't think so) so I have left it running for now.