### PR TITLE
patch respeaker install script to allow qemu installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,10 @@ function install_seeed_voicecard_driver()
     echo "Installing Respeaker Mic Array drivers from source"
     git clone https://github.com/respeaker/seeed-voicecard.git
     cd seeed-voicecard
+    #
+    # change respeaker install.sh to *not* check for bare metal raspi
+    # PR sent to upstream https://github.com/respeaker/seeed-voicecard/pull/147
+    sed -i -e 's/^is_Raspberry=.*/is_Raspberry=Raspberry/' install.sh
     sudo ./install.sh
     cd ..
     #tar -czf ~/seeed-voicecard.tar.gz seeed-voicecard


### PR DESCRIPTION
#### Short description of what this resolves:

respeak installer checks for bare metal raspberry and bails out
if running on a different architecture. This prohibits installation
in a arm qemu, but is not strictly necessary. We have sent a PR
to upstream https://github.com/respeaker/seeed-voicecard/pull/147

#### Changes proposed in this pull request:
Force detection to be Raspberry to make arch check succeed.