### PR TITLE
iface simplification

### DIFF
--- a/access_point/interfaces.d/eth0
+++ b/access_point/interfaces.d/eth0
@@ -1,0 +1,2 @@
+auto eth0
+iface eth0 inet dhcp

--- a/access_point/interfaces.d/wlan.client
+++ b/access_point/interfaces.d/wlan.client
@@ -1,0 +1,3 @@
+allow-hotplug wlan0
+iface wlan0 inet manual
+	wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf

--- a/access_point/interfaces.d/wlan.client
+++ b/access_point/interfaces.d/wlan.client
@@ -1,3 +1,3 @@
 allow-hotplug wlan0
-iface wlan0 inet manual
+iface wlan0 inet dhcp
 	wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf

--- a/access_point/interfaces.d/wlan.hostap
+++ b/access_point/interfaces.d/wlan.hostap
@@ -1,0 +1,7 @@
+allow-hotplug wlan0
+iface wlan0 inet static
+	address 10.0.0.1
+	netmask 255.255.255.0
+	network 10.0.0.0
+	broadcast 10.0.0.255
+

--- a/access_point/rwap.sh
+++ b/access_point/rwap.sh
@@ -14,13 +14,8 @@ cd /etc/hostapd/
 cp hostapd.conf hostapd.conf.bak
 sed -i '1,14d' hostapd.conf
 
-cd /etc/
-cp dhcpcd.conf dhcpcd.conf.bak
-sed -i '57,60d' dhcpcd.conf
-
-cd /etc/network/
-cp interfaces interfaces.bak
-sed -i '9,17d' interfaces
+rm -f /etc/network/interfaces.d/wlan-hostap
+cp /etc/network/interfaces.d/wlan.client /etc/network/interfaces.d/wlan-client
 
 #Empty port 5000
 #Remove the server file from auto-boot

--- a/access_point/wap.sh
+++ b/access_point/wap.sh
@@ -36,22 +36,10 @@ wmm_enabled=1
 ht_capab=[HT40][SHORT-GI-20][DSSS_CCK-40]
 EOF
 
-sed -i -- 's/allow-hotplug wlan0//g' /etc/network/interfaces
-sed -i -- 's/iface wlan0 inet manual//g' /etc/network/interfaces
-sed -i -- 's/    wpa-conf \/etc\/wpa_supplicant\/wpa_supplicant.conf//g' /etc/network/interfaces
 sed -i -- 's/#DAEMON_CONF=""/DAEMON_CONF="\/etc\/hostapd\/hostapd.conf"/g' /etc/default/hostapd
 
-cat >> /etc/network/interfaces <<EOF
-# Added by rPi Access Point Setup
-allow-hotplug wlan0
-iface wlan0 inet static
-	address 10.0.0.1
-	netmask 255.255.255.0
-	network 10.0.0.0
-	broadcast 10.0.0.255
-EOF
-
-echo "denyinterfaces wlan0" >> /etc/dhcpcd.conf
+rm -f /etc/network/interfaces.d/wlan-client
+cp /etc/network/interfaces.d/wlan.hostap /etc/network/interfaces.d/wlan-hostap
 
 systemctl enable hostapd
 systemctl enable dnsmasq

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ disable_ipv6_avahi
 # install wlan config files: files with . in the name are *NOT* include
 # into the global /etc/network/interfaces file, so we can keep them there.
 echo "Installing ETH/WLAN device configuration files"
-sudo bash cp $DIR_PATH/access_point/interfaces.d/* /etc/network/interfaces.d/
+sudo cp $DIR_PATH/access_point/interfaces.d/* /etc/network/interfaces.d/
 
 echo "Converting RasPi into an Access Point"
 sudo bash $DIR_PATH/access_point/wap.sh

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ sudo systemctl enable ssh
 
 cd $DIR_PATH
 echo "Creating a backup folder for future factory_reset"
-rm -Rf .git
+sudo rm -Rf .git
 tar -I 'pixz -p 2' -cf ../reset_folder.tar.xz --checkpoint=.1000 -C .. susi_linux
 echo ""  # To add newline after tar's last checkpoint
 mv ../reset_folder.tar.xz $DIR_PATH/factory_reset/reset_folder.tar.xz

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,11 @@ mv ../reset_folder.tar.xz $DIR_PATH/factory_reset/reset_folder.tar.xz
 
 disable_ipv6_avahi
 
+# install wlan config files: files with . in the name are *NOT* include
+# into the global /etc/network/interfaces file, so we can keep them there.
+echo "Installing ETH/WLAN device configuration files"
+sudo bash cp $DIR_PATH/access_point/interfaces.d/* /etc/network/interfaces.d/
+
 echo "Converting RasPi into an Access Point"
 sudo bash $DIR_PATH/access_point/wap.sh
 

--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,9 @@ sudo bash $DIR_PATH/Deploy/auto_boot.sh
 echo "Enabling the SSH access"
 sudo systemctl enable ssh
 
+echo "Disable dhcpcd"
+sudo systemctl disable dhcpcd
+
 cd $DIR_PATH
 echo "Creating a backup folder for future factory_reset"
 sudo rm -Rf .git


### PR DESCRIPTION
Hi all,

I propose the following change to interface handling.

## Current status

when booting the first time, the unit is in hostap mode with an entry for wlan0
in /etc/network/interfaces. This triggers a failure in the dhcpcd server startup,
since it rejects starting when there are interfaces configured with dhcp or fixed ip
in the interfaces file.

The wap.sh and rwap.sh do complicated sed command to replace lines in the
interface script and restore previous states.

Furthermore, currently the eth0 interface is not acticated by default, which is
also a cosequence of the dhcpcd daemon not starting.

## New solution

Debian/stretch, the basis of Raspian and thus SUSIbian, support /etc/network/interfaces.d/
and reads all files there, but only those where the filename matches alphanumeric.
We provide three files there: eth0, wlan.hostap, wlan.client. The first one defines the
eth0 interface as dhcp based, which makes it available automatically. The other two are
disabled by default (not matching alphanumeric due to the dot).

The wap.sh and rwap.sh only copies their respective files to wlan-hostap and wlan-client,
respectively, and removes the other one, thus activating the wlan device either in hostap
(access point mode) or in client mode (wpa supplicant).

## Tests

The change have been tested on pi-gen generated images.