### PR TITLE
don't use "main" when importing modules

### DIFF
--- a/main/states/susi_state_machine.py
+++ b/main/states/susi_state_machine.py
@@ -69,10 +69,10 @@ class Components:
                 logger.error('Some error occurred in login. Check you login details in config.json.\n%s', e)
 
         if self.config['hotword_engine'] == 'Snowboy':
-            from main.hotword_engine.snowboy_detector import SnowboyDetector
+            from ..hotword_engine.snowboy_detector import SnowboyDetector
             self.hotword_detector = SnowboyDetector()
         else:
-            from main.hotword_engine.sphinx_detector import PocketSphinxDetector
+            from ..hotword_engine.sphinx_detector import PocketSphinxDetector
             self.hotword_detector = PocketSphinxDetector()
 
         if self.config['WakeButton'] == 'enabled':

--- a/main/ui/app_window.py
+++ b/main/ui/app_window.py
@@ -5,13 +5,13 @@ import logging
 import gi
 import json_config
 
-from main.ui import ConfigurationWindow
+from . import ConfigurationWindow
 
 gi.require_version('Gtk', '3.0')  # nopep8
 
 from async_promises import Promise
-from main.ui.animators import ListeningAnimator, ThinkingAnimator
-from main.ui.renderer import Renderer
+from .animators import ListeningAnimator, ThinkingAnimator
+from .renderer import Renderer
 from gi.repository import Gtk
 
 TOP_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/main/ui/renderer.py
+++ b/main/ui/renderer.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractclassmethod
 from rx.subjects import Subject
-from main import SusiStateMachine
+from .. import SusiStateMachine
 
 
 class Renderer(ABC):


### PR DESCRIPTION
currently the top-level module name is hard-coded to "main" which is
a problem when installing into system directories.
Simple renaming does not work, because there are several imports
hard-coded to
```
	import main.abc
```
Change this to use relative imports
```
	import .abc
```
or depending on the depths of hierarchy to
```
	import ..abc
```