### PR TITLE
import GPIO if possible to support GPIO module loading on RPi

### DIFF
--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -13,6 +13,10 @@ from ..speech import TTS
 from .base_state import State
 from .lights import lights
 
+try:
+    import RPi.GPIO as GPIO
+except:
+    pass
 
 logger = logging.getLogger(__name__)
 

--- a/main/states/recognizing_state.py
+++ b/main/states/recognizing_state.py
@@ -8,6 +8,10 @@ from .base_state import State
 from .internet_test import internet_on
 from .lights import lights
 
+try:
+    import RPi.GPIO as GPIO
+except:
+    pass
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Tests on real hardware showed that with `useGPIO=True`, that is on
Raspberry hardware, the recognizing state and busy state cannot
call GPIO because the module is never imported. 

Fix this by loading the module if possible, without erroring out.
We already report whether we support GPIO or not.

The actual calls to GPIO functions are already protected by `useGPIO`
so no further changes are necessary.