### PR TITLE
trigger song_modulation() when speaking stop

### DIFF
--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -122,7 +122,7 @@ class BusyState(State):
             if 'volume' in reply.keys():
                 subprocess.call(['amixer', '-c', '1', 'sset', "'Headphone'", ',', '0', str(reply['volume'])])
                 subprocess.call(['amixer', '-c', '1', 'sset', "'Speaker'", ',', '0', str(reply['volume'])])
-                subprocess.call(['play', os.path.join(self.components.config['data_base_dir'], 
+                subprocess.call(['play', os.path.join(self.components.config['data_base_dir'],
                                                       self.components.config['detection_bell_sound'])])  # nosec #pylint-disable type: ignore
 
             if 'table' in reply.keys():
@@ -157,7 +157,8 @@ class BusyState(State):
                     self.song_modulation('audio_process', 'stop')
                     self.song_modulation('audio_process', 'play')
 
-            if 'stop' in reply.keys():
+            #asking SUSI to stop yields {'answer': ' stopped.'} as a reply
+            if 'stop' in reply.keys() or reply['answer'] == ' stopped.':
                 if hasattr(self, 'video_process'):
                     self.song_modulation('video_process', 'stop')
                 elif hasattr(self, 'audio_process'):


### PR DESCRIPTION
Fixes #503

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [x] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
when saying "stop" the code expects there should be a key named "stop" https://github.com/fossasia/susi_linux/blob/3d43be48d5388d1fdd73374f96de8d27d65cf469/main/states/busy_state.py#L160
but the actual reply from the server is {'answer': ' stopped.'}
#### Changes proposed in this pull request:
handling the actual response and triggering the required function 
