### PR TITLE
Playback of sounds either via python-vlc directly or soundserver

### DIFF
--- a/main/__main__.py
+++ b/main/__main__.py
@@ -2,11 +2,11 @@ import os
 import sys
 import logging
 import argparse
-import subprocess
 
 import colorlog
 
 from . import SusiStateMachine
+from .player import player
 
 
 parser = argparse.ArgumentParser(prog='python3 -m main',
@@ -29,7 +29,7 @@ def get_colorlog_handler(short=False):
 def startup_sound():
     curr_folder = os.path.dirname(os.path.abspath(__file__))
     audio_file = os.path.join(curr_folder, 'wav/ting-ting_susi_has_started.wav')
-    subprocess.Popen(['play', audio_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    player.say(audio_file)
 
 
 if __name__ == '__main__':

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -10,7 +10,7 @@ baseurl = 'http://localhost:7070/'
 
 def send_request(req):
     try:
-        x = requests.get(baseurl + req)
+        requests.get(baseurl + req)
     except Exception as e:
         logger.error(e)
 
@@ -19,19 +19,19 @@ class Player():
         if mode is None:
             mode = default_mode
         if (not mode == 'server') and (not mode == 'direct'):
-            logger.error('unknown mode ', mode, ' trying default mode')
+            logger.error('unknown mode %s, trying default mode', mode)
             mode = default_mode
         if mode == 'server':
             # try to check whether server is available
             try:
                 requests.get(baseurl + 'status')
                 self.mode = 'server'
-            except:
+            except Exception:
                 self.mode = 'direct'
                 logger.info('sound server not available, switching to direct play mode')
         else:
             self.mode = 'direct'
-        logger.info("Player is working in mode: ", self.mode)
+        logger.info('Player is working in mode: %s', self.mode)
 
     def playytb(self, vid, mode = None):
         if (mode == 'server') or ((mode is None) and (self.mode == 'server')):

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -50,7 +50,7 @@ class Player():
             vlcplayer.say(mrl)
     def volume(self, val, use_server = True):
         if use_server:
-            send_request('volume?val=' + val)
+            send_request('volume?val=' + str(val))
         else:
             vlcplayer.volume(val)
     def save_volume(self, use_server = True):

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -1,0 +1,38 @@
+""" Play via sound server """
+
+import logging
+import requests
+
+baseurl = 'http://localhost:7070/'
+
+def send_request(req):
+    try:
+        x = requests.get(baseurl + req)
+    except Exception as e:
+        logger.error(e)
+
+
+class Player():
+    def playytb(self, vid):
+        send_request('play?ytb=' + vid)
+    def play(self, mrl):
+        send_request('play?mrl=' + mrl)
+    def pause(self):
+        send_request('pause')
+    def resume(self):
+        send_request('resume')
+    def stop(self):
+        send_request('stop')
+    def beep(self, mrl):
+        send_request('beep?mrl=' + mrl)
+    def say(self, mrl):
+        send_request('say?mrl=' + mrl)
+    def volume(self, val):
+        send_request('volume?val=' + val)
+    def save_volume(self):
+        send_request('save_volume')
+    def restore_volume(self):
+        send_request('restore_volume')
+
+player = Player()
+

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -4,6 +4,8 @@ import logging
 import requests
 from vlcplayer import vlcplayer
 
+logger = logging.getLogger(__name__)
+default_mode = 'server'
 baseurl = 'http://localhost:7070/'
 
 def send_request(req):
@@ -13,56 +15,77 @@ def send_request(req):
         logger.error(e)
 
 class Player():
-    def playytb(self, vid, use_server = True):
-        if use_server:
+    def __init__(self, mode = None):
+        if mode is None:
+            mode = default_mode
+        if (not mode == 'server') and (not mode == 'direct'):
+            logger.error('unknown mode ', mode, ' trying default mode')
+            mode = default_mode
+        if mode == 'server':
+            # try to check whether server is available
+            try:
+                requests.get(baseurl + 'status')
+                self.mode = 'server'
+            except:
+                self.mode = 'direct'
+                logger.info('sound server not available, switching to direct play mode')
+        else:
+            self.mode = 'direct'
+        logger.info("Player is working in mode: ", self.mode)
+
+    def playytb(self, vid, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('play?ytb=' + vid)
         else:
+            print("==direct playing youtube video ", vid)
             vlcplayer.playytb(vid)
-    def play(self, mrl, use_server = True):
-        if use_server:
+    def play(self, mrl, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('play?mrl=' + mrl)
         else:
+            print("==direct playing mrl ", str(mrl))
             vlcplayer.play(mrl)
-    def pause(self, use_server = True):
-        if use_server:
+    def pause(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('pause')
         else:
             vlcplayer.pause()
-    def resume(self, use_server = True):
-        if use_server:
+    def resume(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('resume')
         else:
             vlcplayer.resume()
-    def stop(self, use_server = True):
-        if use_server:
+    def stop(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('stop')
         else:
             vlcplayer.stop()
-    def beep(self, mrl, use_server = True):
-        if use_server:
+    def beep(self, mrl, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('beep?mrl=' + mrl)
         else:
             vlcplayer.beep(mrl)
-    def say(self, mrl, use_server = True):
-        if use_server:
+    def say(self, mrl, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('say?mrl=' + mrl)
         else:
             vlcplayer.say(mrl)
-    def volume(self, val, use_server = True):
-        if use_server:
+    def volume(self, val, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('volume?val=' + str(val))
         else:
             vlcplayer.volume(val)
-    def save_volume(self, use_server = True):
-        if use_server:
+    def save_volume(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('save_volume')
         else:
             vlcplayer.save_volume()
-    def restore_volume(self, use_server = True):
-        if use_server:
+    def restore_volume(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('restore_volume')
         else:
             vlcplayer.restore_volume()
+
 
 player = Player()
 

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 import requests
+from vlcplayer import vlcplayer
 
 baseurl = 'http://localhost:7070/'
 
@@ -11,28 +12,57 @@ def send_request(req):
     except Exception as e:
         logger.error(e)
 
-
 class Player():
-    def playytb(self, vid):
-        send_request('play?ytb=' + vid)
-    def play(self, mrl):
-        send_request('play?mrl=' + mrl)
-    def pause(self):
-        send_request('pause')
-    def resume(self):
-        send_request('resume')
-    def stop(self):
-        send_request('stop')
-    def beep(self, mrl):
-        send_request('beep?mrl=' + mrl)
-    def say(self, mrl):
-        send_request('say?mrl=' + mrl)
-    def volume(self, val):
-        send_request('volume?val=' + val)
-    def save_volume(self):
-        send_request('save_volume')
-    def restore_volume(self):
-        send_request('restore_volume')
+    def playytb(self, vid, use_server = True):
+        if use_server:
+            send_request('play?ytb=' + vid)
+        else:
+            vlcplayer.playytb(vid)
+    def play(self, mrl, use_server = True):
+        if use_server:
+            send_request('play?mrl=' + mrl)
+        else:
+            vlcplayer.play(mrl)
+    def pause(self, use_server = True):
+        if use_server:
+            send_request('pause')
+        else:
+            vlcplayer.pause()
+    def resume(self, use_server = True):
+        if use_server:
+            send_request('resume')
+        else:
+            vlcplayer.resume()
+    def stop(self, use_server = True):
+        if use_server:
+            send_request('stop')
+        else:
+            vlcplayer.stop()
+    def beep(self, mrl, use_server = True):
+        if use_server:
+            send_request('beep?mrl=' + mrl)
+        else:
+            vlcplayer.beep(mrl)
+    def say(self, mrl, use_server = True):
+        if use_server:
+            send_request('say?mrl=' + mrl)
+        else:
+            vlcplayer.say(mrl)
+    def volume(self, val, use_server = True):
+        if use_server:
+            send_request('volume?val=' + val)
+        else:
+            vlcplayer.volume(val)
+    def save_volume(self, use_server = True):
+        if use_server:
+            send_request('save_volume')
+        else:
+            vlcplayer.save_volume()
+    def restore_volume(self, use_server = True):
+        if use_server:
+            send_request('restore_volume')
+        else:
+            vlcplayer.restore_volume()
 
 player = Player()
 

--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -37,13 +37,11 @@ class Player():
         if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('play?ytb=' + vid)
         else:
-            print("==direct playing youtube video ", vid)
             vlcplayer.playytb(vid)
     def play(self, mrl, mode = None):
         if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('play?mrl=' + mrl)
         else:
-            print("==direct playing mrl ", str(mrl))
             vlcplayer.play(mrl)
     def pause(self, mode = None):
         if (mode == 'server') or ((mode is None) and (self.mode == 'server')):

--- a/main/speech/TTS.py
+++ b/main/speech/TTS.py
@@ -11,6 +11,7 @@ import json_config
 from google_speech import Speech
 from watson_developer_cloud import TextToSpeechV1
 
+from ..player import player
 
 logger = logging.getLogger(__name__)
 config = json_config.connect('config.json')
@@ -37,7 +38,7 @@ def speak_flite_tts(text):
         fdout, wav_output = tempfile.mkstemp(suffix='.wav', dir=tmpdirname)
         subprocess.call(   # nosec #pylint-disable type: ignore
             ['flite', '-v', '-voice', 'file://' + flite_speech_file, '-f', filename, '-o', wav_output])   # nosec #pylint-disable type: ignore
-        subprocess.call(['play', wav_output])   # nosec #pylint-disable type: ignore
+        player.say(wav_output)
 
 
 def speak_watson_tts(text):
@@ -53,7 +54,7 @@ def speak_watson_tts(text):
                 text_to_speech.synthesize(text, accept='audio/wav',
                                           voice=config['watson_tts_config']['voice']))
 
-        subprocess.call(['play', wav_output])   # nosec #pylint-disable type: ignore
+        player.say(wav_output)
 
 
 def speak_google_tts(text):
@@ -63,4 +64,7 @@ def speak_google_tts(text):
     :return: None
     """
     sox_effects = ("tempo", "1.2", "pitch", "2", "speed", "1")
+    player.save_volume()
+    player.volume(20)
     Speech(text=text, lang='en').play(sox_effects)
+    player.restore_volume()

--- a/main/states/base_state.py
+++ b/main/states/base_state.py
@@ -11,7 +11,6 @@ class State(ABC):
     """State is an abstract class to represent a state. It defines the abstract method for behavior of state and
     transition method to facilitate transition between states.
     """
-    audio_process = None
     def __init__(self, components):
         self.components = components
         self.allowedStateTransitions = {}

--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -54,10 +54,9 @@ class BusyState(State):
 
             if 'identifier' in reply.keys():
                 classifier = reply['identifier']
-                #stopAction = StopDetector(self.detection)
                 if classifier[:3] == 'ytd':
                     video_url = reply['identifier']
-                    player.playytb(ideo_url[4:])
+                    player.playytb(video_url[4:])
                     self.transition(self.allowedStateTransitions.get('idle'))
 
                 else:

--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -66,7 +66,7 @@ class BusyState(State):
                     no_answer_needed = True
                     player.restart()    # TODO not implemented!
                 else:
-                    logger.error("Unknown media action: ", action)
+                    logger.error('Unknown media action: %s', action)
 
             # {'stop': <susi_python.models.StopAction object at 0x7f4641598d30>}
             if 'stop' in reply.keys():

--- a/main/states/error_state.py
+++ b/main/states/error_state.py
@@ -2,10 +2,10 @@
 """
 import logging
 import os
-import subprocess   # nosec #pylint-disable type: ignore
 import json_config
 from .base_state import State
 from .lights import lights
+from ..player import player
 
 config = json_config.connect('config.json')
 logger = logging.getLogger(__name__)
@@ -24,8 +24,8 @@ class ErrorState(State):
         if payload == 'RecognitionError':
             self.notify_renderer('error', 'recognition')
             lights.speak()
-            subprocess.call(['play', os.path.join(self.components.config['data_base_dir'],
-                                                  self.components.config['recognition_error_sound'])])
+            player.say(os.path.abspath(os.path.join(self.components.config['data_base_dir'],
+                                                    self.components.config['recognition_error_sound'])))
             lights.off()
         elif payload == 'ConnectionError':
             self.notify_renderer('error', 'connection')
@@ -33,15 +33,14 @@ class ErrorState(State):
             config['default_stt'] = 'pocket_sphinx'
             print("Internet Connection not available")
             lights.speak()
-            # subprocess.call(['play', 'extras/connect-error.wav'])   # nosec #pylint-disable type: ignore
             lights.off()
             logger.info("Changed to offline providers")
         else:
             print("Error: {} \n".format(payload))
             self.notify_renderer('error')
             lights.speak()
-            subprocess.call(['play', os.path.join(self.components.config['data_base_dir'],
-                                                  self.components.config['problem_sound'])])   # nosec #pylint-disable type: ignore
+            player.say(os.path.abspath(os.path.join(self.components.config['data_base_dir'],
+                                                    self.components.config['problem_sound'])))
             lights.off()
 
         self.transition(self.allowedStateTransitions.get('idle'))

--- a/main/states/idle_state.py
+++ b/main/states/idle_state.py
@@ -3,12 +3,11 @@
 
 import logging
 import os
-import subprocess   # nosec #pylint-disable type: ignore
 import signal
 
 from .base_state import State
 from .lights import lights
-
+from ..player import player
 
 logger = logging.getLogger(__name__)
 
@@ -45,14 +44,10 @@ class IdleState(State):
 
     def __detected(self):
         if (self.isActive):
-            if self.audio_process != None:
-                self.audio_process.send_signal(signal.SIGSTOP)
-            subprocess.Popen(['play', os.path.join(self.components.config['data_base_dir'],
-                                                   self.components.config['detection_bell_sound'])])  # nosec # pylint-disable type: ignore
+            player.beep(os.path.abspath(os.path.join(self.components.config['data_base_dir'],
+                                                     self.components.config['detection_bell_sound'])))
             self.transition(state=self.allowedStateTransitions.get(
                 'recognizing'), payload=None)
-            if self.audio_process != None:
-                self.audio_process.send_signal(signal.SIGCONT)
 
     def on_exit(self):
         """Method to be executed on exit from Idle State. Detection of Hotword and Wake Button is paused.

--- a/main/states/recognizing_state.py
+++ b/main/states/recognizing_state.py
@@ -7,6 +7,7 @@ import speech_recognition as sr
 from .base_state import State
 from .internet_test import internet_on
 from .lights import lights
+from ..player import player
 
 try:
     import RPi.GPIO as GPIO
@@ -95,6 +96,8 @@ class RecognizingState(State):
         """ Method to executed upon exit from Recognizing State.
         :return:
         """
+        # we saved the volume when doing a beep
+        player.restore_volume()
         if self.useGPIO:
             try:
                 GPIO.output(27, False)


### PR DESCRIPTION
The following PR adds an abstraction `player` that is used to play music, videos,
beeps, adjust volume etc etc.

The actual module player can operate in two modes:
- direct play using `python-vlc`, using the module `VlcPlayer` (in `susi_installer`)
- playback via soundserver 

The soundserver and VlcPlayer module are in `susi_installer`.

By default the sound server is used, but on initialization the availability is tested
and if hte server is not available, we switch to direct playback.

Reason
---------
- Support contorl of playback of music from mobile apps
- simplify code of sound output
- full featured susi hotword and answering during playback

Properties
-------------
- music playback's volume is reduced during voice detection and answering
- volume is restored after Susi said something (liek "whats the time")

How to test
---------------
After starting susi_server, start susi_linux the usual way, but help locating the vlcplaye rmodule:
```
PYTHONPATH=<PATH-TO>/susi_installer/ python3 -m main -v -v
```
This should work even without a sound server

If you want to test the sound server, call
```
python3 <PATH-TO>/susi_installer/soundserver/soundserver.py
```

After that restart susi_linux, and all output should be done via the sound server
and connectins are logged.

Todo
------
- Integration into the build process and running: finding of modules