### PR TITLE
add restart in player

### DIFF
--- a/main/player/__init__.py
+++ b/main/player/__init__.py
@@ -63,6 +63,11 @@ class Player():
             send_request('previous')
         else:
             vlcplayer.previous()
+    def restart(self, mode = None):
+        if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
+            send_request('restart')
+        else:
+            vlcplayer.restart()
     def stop(self, mode = None):
         if (mode == 'server') or ((mode is None) and (self.mode == 'server')):
             send_request('stop')

--- a/main/states/busy_state.py
+++ b/main/states/busy_state.py
@@ -64,7 +64,7 @@ class BusyState(State):
                     player.resume()
                 elif action == 'restart':
                     no_answer_needed = True
-                    player.restart()    # TODO not implemented!
+                    player.restart()
                 elif action == 'next':
                     no_answer_needed = True
                     player.next()


### PR DESCRIPTION
Fixes #516

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [x] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- Adding the restart method in the player class so that it can trigger audio restart in the vlcplayer

