### PR TITLE
rewrite locale strings to IETF standard and check for model existence

### DIFF
--- a/main/states/recognizing_state.py
+++ b/main/states/recognizing_state.py
@@ -41,7 +41,14 @@ class RecognizingState(State):
                 self.components.config['default_stt'] = 'google'
                 return recognizer.recognize_google(audio, language=susi_config["language"])
             else:
-                return recognizer.recognize_sphinx(audio, language=susi_config["language"])
+                if susi_config["language"][0:2] == 'it' and 'it-IT' in self.components.pocketsphinx_supported_langs:
+                    sphinxlang = 'it-IT'
+                elif susi_config["language"][0:2] == 'zh' and 'zh-CN' in self.components.pocketsphinx_supported_langs:
+                    sphinxlang = 'zh-CN'
+                else:
+                    # fall back to English
+                    sphinxlang = 'en-US'
+                return recognizer.recognize_sphinx(audio, sphinxlang)
 
         elif self.components.config['default_stt'] == 'bing':
             api_key = self.components.config['bing_speech_api_key']

--- a/main/states/susi_state_machine.py
+++ b/main/states/susi_state_machine.py
@@ -8,7 +8,8 @@ from urllib.parse import urljoin
 
 import requests
 import json_config
-
+import os
+import speech_recognition
 from speech_recognition import Recognizer, Microphone
 from requests.exceptions import ConnectionError
 
@@ -90,6 +91,9 @@ class Components:
         else:
             logger.warning("Susi has the wake button disabled")
             self.wake_button = None
+
+        # determine PocketSphinx supported languages
+        self.pocketsphinx_supported_langs = os.listdir(os.path.dirname(speech_recognition.__file__) + '/pocketsphinx-data')
 
     def server_checker(self):
         response_one = None


### PR DESCRIPTION
Fixes #525

The strings used by PocketShpinx to identfy languages are IETF standard (ll-CC) while we save the locale string in susi config. This PR does:
* checks for the available language models in the installation directory of pocketsphinx
* rewrites current languages to either a supported one or English

This is the same behavior as before, where English was hard-coded.
